### PR TITLE
#6 hostname cruft left in /etc/hosts

### DIFF
--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -199,5 +199,9 @@
   command: waagent -deprovision+user -force
   when: cleanup_vm_waagent.stat.exists
 
+- name: Remove installer from /etc/hosts
+  shell:
+    cmd: sed -i'' '/{{ ansible_hostname }}/d' /etc/hosts
+
 - name: Run fstrim
   shell: /usr/sbin/fstrim -a

--- a/ansible/roles/smartos_guest/files/lib/smartdc/firstboot
+++ b/ansible/roles/smartos_guest/files/lib/smartdc/firstboot
@@ -23,6 +23,27 @@ lib_smartdc_info "Start of $(basename "$0") script"
 # Set hostid
 (/lib/smartdc/set-hostid)
 
+#
+# Make sure the localhost has a hostname alias in the zone's
+# /etc/hosts file
+#
+lib_smartdc_info "Ensuring /etc/hosts contains $HOSTNAME"
+hname=$HOSTNAME
+hostfile=/etc/hosts
+tmpfile=$(mktemp /dev/shm/hosts.XXXXXX)
+if [[ -f $hostfile && ! -h $hostfile ]]; then
+	# use awk to search and append to loopback in one command
+	awk -v hname="$hname" '{
+	    if ($1 ~ /^127\./ && index($0, hname) == 0) {
+		printf("%s %s\n", $0, hname);
+	    } else {
+		print $0
+	    }
+	}' $hostfile > "$tmpfile"
+	mv "$tmpfile" "$hostfile"
+	chmod 644 $hostfile
+fi
+
 # Disable firstboot once all scripts are run
 lib_smartdc_info "Disabling firstboot"
 touch /lib/smartdc/.firstboot-complete-do-not-delete

--- a/ansible/roles/smartos_guest/tasks/Ubuntu.yml
+++ b/ansible/roles/smartos_guest/tasks/Ubuntu.yml
@@ -38,6 +38,14 @@
     - usbmuxd
     - wireless-regdb
 
+- name: Install packages that may have been unavailable during install
+  ansible.builtin.apt:
+    name "{{ item }}"
+  loop:
+    - net-tools
+    - nftables
+    - iptables
+
 - name: Remove dependencies that are no longer required
   ansible.builtin.apt:
     autoremove: yes

--- a/debian-11.pkr.hcl
+++ b/debian-11.pkr.hcl
@@ -31,7 +31,7 @@ locals {
     "passwd/user-password=${var.ssh_password} ",
     "passwd/user-password-again=${var.ssh_password} ",
     "passwd/username=${var.ssh_username} ",
-    "console=tty0 console=ttyS0,115200n8 verbose",
+    "console=tty0 console=ttyS0,115200n8 verbose ",
     "tsc=reliable ",
     "<f10><wait>"
   ]

--- a/debian-12.pkr.hcl
+++ b/debian-12.pkr.hcl
@@ -13,7 +13,7 @@
  */
 
 locals {
-  debian_12_iso_url      = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.0.0-amd64-netinst.iso"
+  debian_12_iso_url      = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.1.0-amd64-netinst.iso"
   debian_12_iso_checksum = "file:https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS"
 
   debian_12_boot_command = [

--- a/debian-12.pkr.hcl
+++ b/debian-12.pkr.hcl
@@ -31,7 +31,7 @@ locals {
     "passwd/user-password=${var.ssh_password} ",
     "passwd/user-password-again=${var.ssh_password} ",
     "passwd/username=${var.ssh_username} ",
-    "console=tty0 console=ttyS0,115200n8 verbose",
+    "console=tty0 console=ttyS0,115200n8 verbose ",
     "tsc=reliable ",
     "<f10><wait>"
   ]

--- a/http/debian-11.preseed.cfg
+++ b/http/debian-11.preseed.cfg
@@ -114,7 +114,8 @@ tasksel tasksel/first multiselect
 d-i pkgsel/install-recommends boolean false
 d-i pkgsel/include/install-recommends boolean false
 d-i pkgsel/include string acpid cloud-init curl less man ntp \
-    openssh-server parted python3-serial resolvconf vim wget grub-pc-bin
+    openssh-server parted python3-serial resolvconf vim wget grub-pc-bin \
+    net-tools nftables iptables
 
 # Do not look for more software on other CDs
 d-i apt-setup/cdrom/set-first boolean false

--- a/http/debian-12.preseed.cfg
+++ b/http/debian-12.preseed.cfg
@@ -114,7 +114,8 @@ tasksel tasksel/first multiselect
 d-i pkgsel/install-recommends boolean false
 d-i pkgsel/include/install-recommends boolean false
 d-i pkgsel/include string acpid cloud-init curl less man ntp \
-    openssh-server parted python3-serial resolvconf vim wget grub-pc-bin
+    openssh-server parted python3-serial resolvconf vim wget grub-pc-bin \
+    net-tools nftables iptables
 
 # Do not look for more software on other CDs
 d-i apt-setup/cdrom/set-first boolean false

--- a/http/ubuntu/20.04/user-data
+++ b/http/ubuntu/20.04/user-data
@@ -69,6 +69,9 @@ autoinstall:
     install-server: true
     allow-pw: true
 
+  debconf-selections: |
+    cloud-init	cloud-init/datasources	multiselect	SmartOS
+
   packages:
     - openssh-server
     - open-vm-tools
@@ -85,6 +88,7 @@ autoinstall:
     - curtin in-target --target=/target -- grub-install --target=i386-pc /dev/vda
     - curtin in-target --target=/target -- apt-get update
     - curtin in-target --target=/target -- apt-get dist-upgrade --yes
+    - sed -ie 's/ds=nocloud.* //' /target/etc/default/grub
     - |
       if [ -d /sys/firmware/efi ]; then
         apt-get install -y efibootmgr

--- a/http/ubuntu/20.04/user-data
+++ b/http/ubuntu/20.04/user-data
@@ -26,11 +26,6 @@ autoinstall:
       - arches: [default]
         uri: http://ports.ubuntu.com/ubuntu-ports
 
-# parted -s -a optimal /dev/vda -- mkpart biosboot 1MiB 2MiB set 1 bios_grub on
-# parted -s -a optimal /dev/vda -- mkpart '"EFI System Partition"' fat32 2MiB 258MiB set 2 esp on
-# parted -s -a optimal /dev/vda -- mkpart boot xfs 258MiB 1058MiB
-# parted -s -a optimal /dev/vda -- mkpart primary 1058MiB 100%
-
   storage:
     swap:
         size: 0
@@ -78,8 +73,12 @@ autoinstall:
     - openssh-server
     - open-vm-tools
     - cloud-init
+    - tasksel
     - grub-pc-bin
     - linux-image-generic-hwe-20.04
+    - net-tools
+    - nft
+    - iptables
 
   late-commands:
     - sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/g' /target/etc/ssh/sshd_config

--- a/http/ubuntu/20.04/user-data
+++ b/http/ubuntu/20.04/user-data
@@ -73,11 +73,8 @@ autoinstall:
     - openssh-server
     - open-vm-tools
     - cloud-init
-    - tasksel
     - grub-pc-bin
     - linux-image-generic-hwe-20.04
-    - net-tools
-    - nft
     - iptables
 
   late-commands:

--- a/http/ubuntu/22.04/user-data
+++ b/http/ubuntu/22.04/user-data
@@ -73,12 +73,12 @@ autoinstall:
     - openssh-server
     - open-vm-tools
     - cloud-init
-    - whois
-    - zsh
-    - wget
     - tasksel
     - grub-pc-bin
     - linux-image-generic-hwe-22.04
+    - net-tools
+    - nft
+    - iptables
 
   late-commands:
     - sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/g' /target/etc/ssh/sshd_config
@@ -86,6 +86,8 @@ autoinstall:
     - parted /dev/vda set 1 bios_grub on
     - parted /dev/vda set 2 esp on
     - curtin in-target --target=/target -- grub-install --target=i386-pc /dev/vda
+    - curtin in-target --target=/target -- apt-get update
+    - curtin in-target --target=/target -- apt-get dist-upgrade --yes
     - |
       if [ -d /sys/firmware/efi ]; then
         apt-get install -y efibootmgr

--- a/http/ubuntu/22.04/user-data
+++ b/http/ubuntu/22.04/user-data
@@ -73,11 +73,10 @@ autoinstall:
     - openssh-server
     - open-vm-tools
     - cloud-init
-    - tasksel
     - grub-pc-bin
     - linux-image-generic-hwe-22.04
     - net-tools
-    - nft
+    - nftables
     - iptables
 
   late-commands:

--- a/http/ubuntu/22.04/user-data
+++ b/http/ubuntu/22.04/user-data
@@ -69,6 +69,9 @@ autoinstall:
     install-server: true
     allow-pw: true
 
+  debconf-selections: |
+    cloud-init	cloud-init/datasources	multiselect	SmartOS
+
   packages:
     - openssh-server
     - open-vm-tools
@@ -87,6 +90,7 @@ autoinstall:
     - curtin in-target --target=/target -- grub-install --target=i386-pc /dev/vda
     - curtin in-target --target=/target -- apt-get update
     - curtin in-target --target=/target -- apt-get dist-upgrade --yes
+    - sed -ie 's/ds=nocloud.* //' /target/etc/default/grub
     - |
       if [ -d /sys/firmware/efi ]; then
         apt-get install -y efibootmgr


### PR DESCRIPTION
This also fixes an issue where updating cloud-init will stop recognizing the SmartOS cloud provider.