### PR TITLE
IMAGE-1202 Debian HVM images end up with hard coded resolvers

### DIFF
--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -117,6 +117,13 @@
     - /var/log/spooler
   ignore_errors: true
 
+- name: Clean debian interfaces config
+  ansible.builtin.lineinfile:
+    path: /etc/network/interfaces
+    regexp: "^(# The|auto|iface|allow).*"
+    state: absent
+  when: ansible_os_family == "Debian" and ansible_distribution != "Ubuntu"
+
 - name: Remove log folders.
   file:
     path: "{{ item }}"

--- a/ansible/roles/smartos_guest/tasks/Debian.yml
+++ b/ansible/roles/smartos_guest/tasks/Debian.yml
@@ -5,15 +5,6 @@
 # Copyright 2023 MNX Cloud, Inc.
 
 ---
-- name: Setup resolvconf /etc/resolvconf/resolv.conf.d/head
-  copy:
-    src: head
-    dest: /etc/resolvconf/resolv.conf.d/head
-    owner: root
-    group: root
-    mode: 0644
-  when: ansible_distribution != "Ubuntu"
-
 - name: Remove dependencies that are no longer required
   ansible.builtin.apt:
     autoremove: yes


### PR DESCRIPTION
Tested this by creating debian-11 and debian-12 images from this branch.

## Debian 11

No cruft in interfaces file

```
root@deb11:~# cat /etc/network/interfaces 
# This file describes the network interfaces available on your system
# and how to activate them. For more information, see interfaces(5).

source /etc/network/interfaces.d/*


```

cloud-init properly added resolvers to generated interface file

```
root@deb11:~# cat /etc/network/interfaces.d/50-cloud-init 
# This file is generated from information provided by the datasource.  Changes
# to it will not persist across an instance reboot.  To disable cloud-init's
# network configuration capabilities, write a file
# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
# network: {config: disabled}
auto lo
iface lo inet loopback
    dns-nameservers 8.8.8.8 8.8.4.4

auto net0
iface net0 inet static
    address 172.25.4.162/24
    gateway 172.25.4.1
    mtu 1500

auto net1
iface net1 inet static
    address 172.25.8.98/24
    mtu 1500
```

Nothing extra in `resolv.conf.d/head`

```
root@deb11:~# cat /etc/resolvconf/resolv.conf.d/head 
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
#     DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "resolvectl status" to see details about the actual nameservers.

```

Correct resolvers

```
root@deb11:~# cat /etc/resolv.conf 
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
#     DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "resolvectl status" to see details about the actual nameservers.

nameserver 8.8.8.8
nameserver 8.8.4.4
```

## Debian 12

No cruft in interfaces file

```
root@deb12:~# cat /etc/network/interfaces
# This file describes the network interfaces available on your system
# and how to activate them. For more information, see interfaces(5).

source /etc/network/interfaces.d/*


```

cloud-init properly added resolvers to generated interface file

```
root@deb12:~# cat /etc/network/interfaces.d/50-cloud-init
# This file is generated from information provided by the datasource.  Changes
# to it will not persist across an instance reboot.  To disable cloud-init's
# network configuration capabilities, write a file
# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
# network: {config: disabled}
auto lo
iface lo inet loopback
    dns-nameservers 8.8.8.8 8.8.4.4

auto net0
iface net0 inet static
    address 172.25.4.163/24
    gateway 172.25.4.1
    mtu 1500

auto net1
iface net1 inet static
    address 172.25.8.99/24
    mtu 1500
```

Nothing extra in `resolv.conf.d/head`

```
root@deb12:~# cat /etc/resolvconf/resolv.conf.d/head
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
#     DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "resolvectl status" to see details about the actual nameservers.

```

Correct resolvers

```
root@deb12:~# cat /etc/resolv.conf
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
#     DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "resolvectl status" to see details about the actual nameservers.

nameserver 8.8.8.8
nameserver 8.8.4.4
```