### PR TITLE
Update debian-12 version to 12.5.0.

### DIFF
--- a/debian-12.pkr.hcl
+++ b/debian-12.pkr.hcl
@@ -13,7 +13,7 @@
  */
 
 locals {
-  debian_12_ver          = "12.2.0"
+  debian_12_ver          = "12.5.0"
   debian_12_iso_url      = "https://cdimage.debian.org/debian-cd/${local.debian_12_ver}/amd64/iso-cd/debian-${local.debian_12_ver}-amd64-netinst.iso"
   debian_12_iso_checksum = "file:https://cdimage.debian.org/debian-cd/${local.debian_12_ver}/amd64/iso-cd/SHA256SUMS"
 


### PR DESCRIPTION
Update to 12.5.0, as defined URLs to 12.2.0 are not available anymore.