### PR TITLE
TOOLS-2580: Update triton-cloud-images to get all images building again

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-    Copyright 2024 MNX Cloud, Inc.
+    Copyright 2025 MNX Cloud, Inc.
  -->
 
 # Triton DataCenter and SmartOS Cloud Images
@@ -48,7 +48,7 @@ Building images requires additional services to be installed, running, and prope
 
 ### Granting permission for a zone to use Bhyve
 
-You must use a `joyent` brand zone `base-64-lts@22.4.0` or later, with a delegated dataset. The nic will need `"allow_ip_spoofing": true`. If you are using a stand-alone SmartOS server, add this to the JSON when creating the zone. If you are using Triton, you will need to add it via NAPI (AdminUI can also be used). For example:
+You must use a `joyent` brand zone `base-64-lts@22.4.0` with a delegated dataset. The nic will need `"allow_ip_spoofing": true`. If you are using a stand-alone SmartOS server, add this to the JSON when creating the zone. If you are using Triton, you will need to add it via NAPI (AdminUI can also be used). For example:
 
 ```sh
 sdc-napi /nics/00:53:37:aa:bb:cc -X PUT -d '{"allow_ip_spoofing": true}'

--- a/build_all.sh
+++ b/build_all.sh
@@ -7,7 +7,7 @@
 #
 
 #
-# Copyright 2024 MNX Cloud, Inc.
+# Copyright 2025 MNX Cloud, Inc.
 #
 
 if [[ -n "$TRACE" ]]; then
@@ -208,8 +208,6 @@ if [[ $1 == "list" ]]; then
     exit
 fi
 
-[[ -d $PACKER_PLUGIN_PATH ]] || packer_init
-
 case "$1" in
     *deps)
         # Q: Why do this here and also below, outside of the case statement?
@@ -238,6 +236,7 @@ else
 fi
 
 ensure_deps
+[[ -d $PACKER_PLUGIN_PATH ]] || packer_init
 ensure_services
 
 # Build any images passed on the command line, or all.

--- a/debian-12.pkr.hcl
+++ b/debian-12.pkr.hcl
@@ -9,11 +9,11 @@
  */
 
 /*
- * Copyright 2023 MNX Cloud, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 locals {
-  debian_12_ver          = "12.5.0"
+  debian_12_ver          = "12.9.0"
   debian_12_iso_url      = "https://cdimage.debian.org/debian-cd/${local.debian_12_ver}/amd64/iso-cd/debian-${local.debian_12_ver}-amd64-netinst.iso"
   debian_12_iso_checksum = "file:https://cdimage.debian.org/debian-cd/${local.debian_12_ver}/amd64/iso-cd/SHA256SUMS"
 

--- a/ubuntu-22.04.pkr.hcl
+++ b/ubuntu-22.04.pkr.hcl
@@ -9,11 +9,11 @@
  */
 
 /*
- * Copyright 2023 MNX Cloud, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 locals {
-  ubuntu_22_ver          = "22.04.4"
+  ubuntu_22_ver          = "22.04.5"
   ubuntu_22_iso_url      = "https://releases.ubuntu.com/jammy/ubuntu-${local.ubuntu_22_ver}-live-server-amd64.iso"
   ubuntu_22_iso_checksum = "file:https://releases.ubuntu.com/jammy/SHA256SUMS"
 

--- a/ubuntu-24.04.pkr.hcl
+++ b/ubuntu-24.04.pkr.hcl
@@ -9,11 +9,11 @@
  */
 
 /*
- * Copyright 2024 MNX Cloud, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 locals {
-  ubuntu_24_ver          = "24.04"
+  ubuntu_24_ver          = "24.04.2"
   ubuntu_24_iso_url      = "https://releases.ubuntu.com/noble/ubuntu-${local.ubuntu_24_ver}-live-server-amd64.iso"
   ubuntu_24_iso_checksum = "file:https://releases.ubuntu.com/noble/SHA256SUMS"
 


### PR DESCRIPTION
<https://smartos.org/bugview/TOOLS-2580>

This PR does three things:

- Fixes the documentation to not suggest that untested newer images probably work. This wasted my time.
- Fixes an ordering issue in build_all.sh that a fresh zone trips over. Now the script works in a fresh zone on the first try.
- Updates the version numbers for Ubuntu 22.04, 24.04, and Debian 12 to the versions that are currently available.