### PR TITLE
IMAGE-1204: Want Oracle Enterprise Linux

### DIFF
--- a/ansible/roles/smartos_guest/tasks/OracleLinux.yml
+++ b/ansible/roles/smartos_guest/tasks/OracleLinux.yml
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Copyright 2025 MNX Cloud, Inc.
+
+- name: Run common tasks for RedHat derivatives
+  include_tasks: RedHat.yml
+
+- name: Install DTrace
+  dnf:
+    name:
+      - dtrace

--- a/http/almalinux-8-lvm.ks
+++ b/http/almalinux-8-lvm.ks
@@ -28,7 +28,6 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
 bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 tsc=reliable no_timer_check" --location=mbr --timeout=1
 
 # Partition stuff

--- a/http/almalinux-8.ks
+++ b/http/almalinux-8.ks
@@ -28,7 +28,6 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
 bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 tsc=reliable no_timer_check" --location=mbr --timeout=1
 
 # Partition stuff

--- a/http/oraclelinux-8.ks
+++ b/http/oraclelinux-8.ks
@@ -1,0 +1,76 @@
+# OracleLinux 8 kickstart file for Generic Cloud (OpenStack) image
+
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright 2023 MNX Cloud, Inc.
+#
+
+url --url https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64/
+repo --name=BaseOS --baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64/
+repo --name=AppStream --baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang en_US.UTF-8
+keyboard us
+timezone UTC --isUtc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 tsc=reliable no_timer_check" --location=mbr --timeout=1
+
+# Partition stuff
+%pre --erroronfail
+
+parted -s -a optimal /dev/vda -- mklabel gpt
+parted -s -a optimal /dev/vda -- mkpart biosboot 1MiB 2MiB set 1 bios_grub on
+parted -s -a optimal /dev/vda -- mkpart '"EFI System Partition"' fat32 2MiB 258MiB set 2 esp on
+parted -s -a optimal /dev/vda -- mkpart boot xfs 258MiB 1058MiB
+parted -s -a optimal /dev/vda -- mkpart primary 1058MiB 100%
+
+%end
+
+
+part biosboot  --fstype=biosboot --onpart=vda1
+part /boot/efi --fstype=efi --onpart=vda2
+part /boot     --fstype=xfs --onpart=vda3
+part /         --fstype=xfs --onpart=vda4
+
+rootpw --plaintext tritondatacenter
+
+reboot --eject
+
+
+%packages
+@core
+python3
+-biosdevname
+-open-vm-tools
+-plymouth
+-dnf-plugin-spacewalk
+-rhn*
+-iprutils
+-iwl*-firmware
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+dnf install -y grub2-efi-x64-modules grub2-pc-modules
+grub2-mkconfig -o /boot/grub2/grub.cfg
+grub2-install --target=i386-pc /dev/vda
+%end

--- a/http/oraclelinux-9.ks
+++ b/http/oraclelinux-9.ks
@@ -1,0 +1,82 @@
+# OracleLinux 9 kickstart file for Generic Cloud (OpenStack) x86_64-v2 image
+
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright 2025 MNX Cloud, Inc.
+#
+
+url --url https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/
+repo --name=BaseOS --baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/
+repo --name=AppStream --baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang C.UTF-8
+keyboard us
+timezone UTC --utc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --timeout=1 --location=mbr --append="console=ttyS0,115200n8 no_timer_check crashkernel=auto tsc=reliable net.ifnames=0"
+
+# Partition stuff
+
+%pre --erroronfail
+
+parted -s -a optimal /dev/vda -- mklabel gpt
+parted -s -a optimal /dev/vda -- mkpart biosboot 1MiB 2MiB set 1 bios_grub on
+parted -s -a optimal /dev/vda -- mkpart '"EFI System Partition"' fat32 2MiB 258MiB set 2 esp on
+parted -s -a optimal /dev/vda -- mkpart boot xfs 258MiB 1058MiB
+parted -s -a optimal /dev/vda -- mkpart primary 1058MiB 100%
+
+%end
+
+
+part biosboot  --fstype=biosboot --onpart=vda1
+part /boot/efi --fstype=efi --onpart=vda2
+part /boot     --fstype=xfs --onpart=vda3
+part /         --fstype=xfs --onpart=vda4
+
+rootpw --plaintext tritondatacenter
+
+reboot
+
+
+%packages --inst-langs=en
+@core
+dracut-config-generic
+usermode
+-biosdevname
+-dnf-plugin-spacewalk
+-dracut-config-rescue
+-iprutils
+-iwl*-firmware
+-langpacks-*
+-mdadm
+-open-vm-tools
+-plymouth
+-rhn*
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+dnf install -y grub2-efi-x64-modules grub2-pc-modules
+grub2-install --target=i386-pc /dev/vda
+%end

--- a/http/rocky-8-lvm.ks
+++ b/http/rocky-8-lvm.ks
@@ -30,7 +30,6 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
 bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 tsc=reliable no_timer_check" --location=mbr --timeout=1
 zerombr
 

--- a/http/rocky-8.ks
+++ b/http/rocky-8.ks
@@ -30,7 +30,6 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
 bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 tsc=reliable no_timer_check" --location=mbr --timeout=1
 zerombr
 

--- a/imgconfigs.json
+++ b/imgconfigs.json
@@ -19,6 +19,16 @@
     "desc": "Debian 12 (bookworm) 64-bit image with just essential packages installed. Built to run on bhyve or KVM virtual machines.",
     "homepage": "https://docs.tritondatacenter.com/public-cloud/instances/virtual-machines/images/linux"
   },
+  "oraclelinux-8": {
+    "os": "linux",
+    "desc": "Oracle Linux 8 64-bit image with just essential packages installed. Built to run on bhyve or KVM virtual machines.",
+    "homepage": "https://docs.tritondatacenter.com/public-cloud/instances/virtual-machines/images/linux"
+  },
+  "oraclelinux-9": {
+    "os": "linux",
+    "desc": "Oracle Linux 9 64-bit image with just essential packages installed. Built to run on bhyve or KVM virtual machines.",
+    "homepage": "https://docs.tritondatacenter.com/public-cloud/instances/virtual-machines/images/linux"
+  },
   "rocky-8": {
     "os": "linux",
     "desc": "Rocky 8 64-bit image with just essential packages installed. Built to run on bhyve or KVM virtual machines.",

--- a/oraclelinux-8.pkr.hcl
+++ b/oraclelinux-8.pkr.hcl
@@ -1,0 +1,71 @@
+/*
+ * OracleLinux 8 Packer template for building Triton DataCenter/SmartOS images
+ */
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2025 MNX Cloud, Inc.
+ */
+
+locals {
+  oraclelinux_8_iso_url      = "https://yum.oracle.com/ISOS/OracleLinux/OL8/u10/x86_64/OracleLinux-R8-U10-x86_64-boot.iso"
+  oraclelinux_8_iso_checksum = "file:https://linux.oracle.com/security/gpg/checksum/OracleLinux-R8-U10-Server-x86_64.checksum"
+
+  oraclelinux_8_boot_command_uefi = [
+    "c<wait>",
+    "linuxefi /images/pxeboot/vmlinuz inst.repo=cdrom ",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=${var.base_url}/oraclelinux-8.ks<enter>",
+    "initrdefi /images/pxeboot/initrd.img<enter>",
+    "boot<enter><wait>"
+  ]
+}
+
+source "bhyve" "oraclelinux-8-x86_64" {
+  boot_command       = local.oraclelinux_8_boot_command_uefi
+  boot_wait          = var.boot_wait
+  cpus               = var.cpus
+  disk_size          = var.disk_size
+  disk_use_zvol      = var.disk_use_zvol
+  disk_zpool         = var.disk_zpool
+  host_nic           = var.host_nic
+  http_directory     = var.http_directory
+  iso_checksum       = local.oraclelinux_8_iso_checksum
+  iso_url            = local.oraclelinux_8_iso_url
+  memory             = var.memory
+  shutdown_command   = var.root_shutdown_command
+  ssh_password       = var.ssh_password
+  ssh_timeout        = var.ssh_timeout
+  ssh_username       = var.ssh_username
+  vm_name            = "oraclelinux-8-${formatdate("YYYYMMDD", timestamp())}.x86_64.zfs"
+  vnc_bind_address   = var.vnc_bind_address
+  vnc_use_password   = var.vnc_use_password
+  vnc_port_min       = var.vnc_port_min
+  vnc_port_max       = var.vnc_port_max
+}
+
+build {
+  sources = [
+    "bhyve.oraclelinux-8-x86_64"
+  ]
+
+  provisioner "ansible" {
+    playbook_file    = "./ansible/smartos.yml"
+    galaxy_file      = "./ansible/requirements.yml"
+    roles_path       = "./ansible/roles"
+    collections_path = "./ansible/collections"
+    extra_arguments = [
+      "--scp-extra-args", "'-O '",
+      "--ssh-extra-args", "-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa -o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes"
+    ]
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+    ]
+  }
+}

--- a/oraclelinux-9.pkr.hcl
+++ b/oraclelinux-9.pkr.hcl
@@ -1,0 +1,71 @@
+/*
+ * OracleLinux 9 Packer template for building Triton DataCenter/SmartOS images
+ */
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2025 MNX Cloud, Inc.
+ */
+
+locals {
+  oraclelinux_9_iso_url      = "https://yum.oracle.com/ISOS/OracleLinux/OL9/u5/x86_64/OracleLinux-R9-U5-x86_64-boot.iso"
+  oraclelinux_9_iso_checksum = "file:https://linux.oracle.com/security/gpg/checksum/OracleLinux-R9-U5-Server-x86_64.checksum"
+
+  oraclelinux_9_boot_command_uefi = [
+    "c<wait>",
+    "linuxefi /images/pxeboot/vmlinuz inst.repo=cdrom ",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=${var.base_url}/oraclelinux-9.ks<enter>",
+    "initrdefi /images/pxeboot/initrd.img<enter>",
+    "boot<enter><wait>"
+  ]
+}
+
+source "bhyve" "oraclelinux-9-x86_64" {
+  boot_command       = local.oraclelinux_9_boot_command_uefi
+  boot_wait          = var.boot_wait
+  cpus               = var.cpus
+  disk_size          = var.disk_size
+  disk_use_zvol      = var.disk_use_zvol
+  disk_zpool         = var.disk_zpool
+  host_nic           = var.host_nic
+  http_directory     = var.http_directory
+  iso_checksum       = local.oraclelinux_9_iso_checksum
+  iso_url            = local.oraclelinux_9_iso_url
+  memory             = var.memory
+  shutdown_command   = var.root_shutdown_command
+  ssh_password       = var.ssh_password
+  ssh_timeout        = var.ssh_timeout
+  ssh_username       = var.ssh_username
+  vm_name            = "oraclelinux-9-${formatdate("YYYYMMDD", timestamp())}.x86_64.zfs"
+  vnc_bind_address   = var.vnc_bind_address
+  vnc_use_password   = var.vnc_use_password
+  vnc_port_min       = var.vnc_port_min
+  vnc_port_max       = var.vnc_port_max
+}
+
+build {
+  sources = [
+    "bhyve.oraclelinux-9-x86_64"
+  ]
+
+  provisioner "ansible" {
+    playbook_file    = "./ansible/smartos.yml"
+    galaxy_file      = "./ansible/requirements.yml"
+    roles_path       = "./ansible/roles"
+    collections_path = "./ansible/collections"
+    extra_arguments = [
+      "--scp-extra-args", "'-O '",
+      "--ssh-extra-args", "-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa -o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes"
+    ]
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+    ]
+  }
+}


### PR DESCRIPTION
https://smartos.org/bugview/IMAGE-1204
Fixes #21
Supersedes #13

Testing notes:
I was able to boot into these images. I verified that the 9 image also works if set for BIOS boot. I was able to SSH in using a key from the metadata. `dtrace` is also installed.