### PR TITLE
bump debian 12 to 12.10

### DIFF
--- a/debian-12.pkr.hcl
+++ b/debian-12.pkr.hcl
@@ -13,7 +13,7 @@
  */
 
 locals {
-  debian_12_ver          = "12.9.0"
+  debian_12_ver          = "12.10.0"
   debian_12_iso_url      = "https://cdimage.debian.org/debian-cd/${local.debian_12_ver}/amd64/iso-cd/debian-${local.debian_12_ver}-amd64-netinst.iso"
   debian_12_iso_checksum = "file:https://cdimage.debian.org/debian-cd/${local.debian_12_ver}/amd64/iso-cd/SHA256SUMS"
 


### PR DESCRIPTION
This is a minor change, but 12.9 is no longer available at https://cdimage.debian.org/debian-cd/ but 12.10 is, and it builds successfully.

